### PR TITLE
Encrypt the access_token in cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+You will need a `RBNACL_SECRET` environment variable to encrypt cached tokens.
+You can generate one using the following code
+
+```
+dd if=/dev/urandom bs=32 count=1 2>/dev/null | openssl base64
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # GitHubIntegration
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/git_hub_integration`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Use GitHub Integration with Octokit.
 
 ## Installation
 

--- a/git_hub_integration.gemspec
+++ b/git_hub_integration.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "octokit", "4.3.1.pre1"
+  spec.add_dependency "rbnacl-libsodium"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/git_hub_integration/token_encryption.rb
+++ b/lib/git_hub_integration/token_encryption.rb
@@ -1,26 +1,30 @@
-module TokenEncryption
-  def self.rbnacl_secret
-    ENV["RBNACL_SECRET"] ||
-      raise("No RBNACL_SECRET environmental variable set")
-  end
+class RbnaclSecretMissing < StandardError; end
 
-  def self.rbnacl_secret_bytes
-    rbnacl_secret.unpack("m0").first
-  end
+module GitHubIntegration
+  module TokenEncryption
+    def self.rbnacl_secret
+      ENV["RBNACL_SECRET"] ||
+        raise(RbnaclSecretMissing, "No RBNACL_SECRET environmental variable set")
+    end
 
-  def self.rbnacl_simple_box
-    @rbnacl_simple_box ||=
-      RbNaCl::SimpleBox.from_secret_key(rbnacl_secret_bytes)
-  end
+    def self.rbnacl_secret_bytes
+      rbnacl_secret.unpack("m0").first
+    end
 
-  def self.decrypt_value(value)
-    rbnacl_simple_box.decrypt(Base64.decode64(value))
-  rescue RbNaCl::CryptoError, NoMethodError
-    nil
-  end
+    def self.rbnacl_simple_box
+      @rbnacl_simple_box ||=
+        RbNaCl::SimpleBox.from_secret_key(rbnacl_secret_bytes)
+    end
 
-  def self.encrypt_value(value)
-    return if value.nil? || value == ""
-    Base64.encode64(rbnacl_simple_box.encrypt(value)).chomp
+    def self.decrypt_value(value)
+      rbnacl_simple_box.decrypt(Base64.decode64(value))
+    rescue RbNaCl::CryptoError, NoMethodError
+      nil
+    end
+
+    def self.encrypt_value(value)
+      return if value.nil? || value == ""
+      Base64.encode64(rbnacl_simple_box.encrypt(value)).chomp
+    end
   end
 end

--- a/lib/git_hub_integration/token_encryption.rb
+++ b/lib/git_hub_integration/token_encryption.rb
@@ -1,0 +1,26 @@
+module TokenEncryption
+  def self.rbnacl_secret
+    ENV["RBNACL_SECRET"] ||
+      raise("No RBNACL_SECRET environmental variable set")
+  end
+
+  def self.rbnacl_secret_bytes
+    rbnacl_secret.unpack("m0").first
+  end
+
+  def self.rbnacl_simple_box
+    @rbnacl_simple_box ||=
+      RbNaCl::SimpleBox.from_secret_key(rbnacl_secret_bytes)
+  end
+
+  def self.decrypt_value(value)
+    rbnacl_simple_box.decrypt(Base64.decode64(value))
+  rescue RbNaCl::CryptoError, NoMethodError
+    nil
+  end
+
+  def self.encrypt_value(value)
+    return if value.nil? || value == ""
+    Base64.encode64(rbnacl_simple_box.encrypt(value)).chomp
+  end
+end

--- a/lib/git_hub_integration/token_encryption.rb
+++ b/lib/git_hub_integration/token_encryption.rb
@@ -18,8 +18,6 @@ module GitHubIntegration
 
     def self.decrypt_value(value)
       rbnacl_simple_box.decrypt(Base64.decode64(value))
-    rescue RbNaCl::CryptoError, NoMethodError
-      nil
     end
 
     def self.encrypt_value(value)

--- a/spec/git_hub_integration/token_encryption_spec.rb
+++ b/spec/git_hub_integration/token_encryption_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+RSpec.describe GitHubIntegration::TokenEncryption do
+  it "raise an error when RBNACL_SECRET is missing" do
+    expect do
+      GitHubIntegration::TokenEncryption.encrypt_value("test")
+    end.to raise_error(RbnaclSecretMissing)
+  end
+
+  describe "When RBNACL_SECRET is present" do
+    before do
+      ENV["RBNACL_SECRET"] = "n1v9ITbJ9KIkFa3fqs1XTlUkRToQNmp5Ekqy/aEMooM="
+    end
+
+    after do
+      ENV.delete("RBNACL_SECRET")
+    end
+
+    it "does not raise an error when RBNACL_SECRET is present" do
+      expect do
+        GitHubIntegration::TokenEncryption.encrypt_value("test")
+      end.to_not raise_error(RbnaclSecretMissing)
+    end
+
+    it "encrypts/decrypt the value" do
+      encrypted_value = GitHubIntegration::TokenEncryption.encrypt_value("test")
+      expect(encrypted_value).to_not eql("test")
+      decrypted_value = GitHubIntegration::TokenEncryption.decrypt_value(encrypted_value)
+      expect(decrypted_value).to eql("test")
+    end
+  end
+end

--- a/spec/git_hub_integration_spec.rb
+++ b/spec/git_hub_integration_spec.rb
@@ -1,7 +1,37 @@
 require "spec_helper"
 
 describe GitHubIntegration do
+  before do
+    ENV["RBNACL_SECRET"] = "n1v9ITbJ9KIkFa3fqs1XTlUkRToQNmp5Ekqy/aEMooM="
+  end
+
+  after do
+    ENV.delete("RBNACL_SECRET")
+  end
+
   it "has a version number" do
     expect(GitHubIntegration::VERSION).not_to be nil
+  end
+
+  module Rails
+    class << self
+      attr_reader :key, :value
+    end
+
+    def self.cache
+      self
+    end
+
+    def self.write(key, value)
+      @key = key
+      @value = value
+    end
+  end
+
+  it "stores the token encrypted" do
+    GitHubIntegration.cache_encrypted_token("test")
+    expect(Rails.value).to_not eql "test"
+    decrypted_value = GitHubIntegration::TokenEncryption.decrypt_value(Rails.value)
+    expect(decrypted_value).to eql("test")
   end
 end


### PR DESCRIPTION
We were storing clear tokens in the cache.

This adds an encryption module using `rbnacl-libsodium` to encrypt the token before saving it.

It needs a `RBNACL_SECRET` environment variable to work.